### PR TITLE
updata test case of rest-client

### DIFF
--- a/src/__tests__/lib/rest-client.test.ts
+++ b/src/__tests__/lib/rest-client.test.ts
@@ -36,8 +36,8 @@ describe('rest-client', () => {
     });
 
     describe('execute(): ', () => {
-      it('successfully applies RESTCLient `GET` method to given input.', async () => {
-        expect.assertions(1);
+      it('successfully applies RESTCLient `GET` method to given input. (tls-verify is undefined)', async () => {
+        expect.assertions(3);
         const config = {
           method: 'GET',
           url: 'https://api.example.com/data',
@@ -46,7 +46,12 @@ describe('rest-client', () => {
         };
 
         const restClient = RESTClient(config, parametersMetadata, {});
-        mock.onGet(config.url).reply(200, {data: 100});
+        mock.onGet(config.url).reply(config => {
+          const headers = config.headers ?? {};
+          expect(config.httpsAgent.options.rejectUnauthorized).toBe(true);
+          expect(headers['Content-Type']).toBeUndefined();
+          return [200, {data: 100}];
+        });
 
         const result = await restClient.execute([
           {
@@ -65,19 +70,58 @@ describe('rest-client', () => {
         expect(result).toStrictEqual(expectedResult);
       });
 
-      it('successfully applies RESTClient `PUT` method to given input.', async () => {
-        expect.assertions(1);
+      it('successfully applies RESTCLient `GET` method to given input. (tls-verify is defined)', async () => {
+        expect.assertions(3);
+        const config = {
+          method: 'GET',
+          url: 'https://api.example.com/data',
+          'tls-verify': false,
+          jpath: '$.data',
+          output: 'result',
+        };
+
+        const restClient = RESTClient(config, parametersMetadata, {});
+        mock.onGet(config.url).reply(config => {
+          const headers = config.headers ?? {};
+          expect(config.httpsAgent.options.rejectUnauthorized).toBe(false);
+          expect(headers['Content-Type']).toBeUndefined();
+          return [200, {data: 100}];
+        });
+
+        const result = await restClient.execute([
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+          },
+        ]);
+        const expectedResult = [
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+            result: 100,
+          },
+        ];
+
+        expect(result).toStrictEqual(expectedResult);
+      });
+
+      it('successfully applies RESTClient `PUT` method to given input. (tls-verify is undefined and Content-Type is undefined)', async () => {
+        expect.assertions(3);
         const config = {
           method: 'PUT',
           url: 'https://api.example.com/data',
           data: {data: 100},
           jpath: 'data',
           output: 'result',
-          'tls-verify': true,
         };
 
         const restClient = RESTClient(config, parametersMetadata, {});
-        mock.onPut(config.url, config.data).reply(200, {data: 100});
+        mock.onPut(config.url, config.data).reply(config => {
+          const headers = config.headers ?? {};
+          expect(config.httpsAgent.options.rejectUnauthorized).toBe(true);
+          expect(headers['Content-Type']).toBe('application/json');
+          return [200, {data: 100}];
+        });
 
         const result = await restClient.execute([
           {
@@ -96,8 +140,121 @@ describe('rest-client', () => {
         expect(result).toStrictEqual(expectedResult);
       });
 
-      it('successfully applies RESTClient `POST` method to given input.', async () => {
-        expect.assertions(1);
+      it('successfully applies RESTClient `PUT` method to given input. (tls-verify is defined and Content-Type is undefined)', async () => {
+        expect.assertions(3);
+        const config = {
+          method: 'PUT',
+          url: 'https://api.example.com/data',
+          data: {data: 100},
+          jpath: 'data',
+          output: 'result',
+          'tls-verify': false,
+        };
+
+        const restClient = RESTClient(config, parametersMetadata, {});
+        mock.onPut(config.url, config.data).reply(config => {
+          const headers = config.headers ?? {};
+          expect(config.httpsAgent.options.rejectUnauthorized).toBe(false);
+          expect(headers['Content-Type']).toBe('application/json');
+          return [200, {data: 100}];
+        });
+
+        const result = await restClient.execute([
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+          },
+        ]);
+        const expectedResult = [
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+            result: 100,
+          },
+        ];
+
+        expect(result).toStrictEqual(expectedResult);
+      });
+
+      it('successfully applies RESTClient `PUT` method to given input. (tls-verify is undefined and Content-Type is defined)', async () => {
+        expect.assertions(3);
+        const config = {
+          method: 'PUT',
+          url: 'https://api.example.com/data',
+          data: {data: 100},
+          headers: {
+            'Content-Type': 'application/vnd.test',
+          },
+          jpath: 'data',
+          output: 'result',
+        };
+
+        const restClient = RESTClient(config, parametersMetadata, {});
+        mock.onPut(config.url, config.data).reply(config => {
+          const headers = config.headers ?? {};
+          expect(headers['Content-Type']).toBe('application/vnd.test');
+          expect(config.httpsAgent.options.rejectUnauthorized).toBe(true);
+          return [200, {data: 100}];
+        });
+
+        const result = await restClient.execute([
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+          },
+        ]);
+        const expectedResult = [
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+            result: 100,
+          },
+        ];
+
+        expect(result).toStrictEqual(expectedResult);
+      });
+
+      it('successfully applies RESTClient `PUT` method to given input. (tls-verify is defined and Content-Type is defined)', async () => {
+        expect.assertions(3);
+        const config = {
+          method: 'PUT',
+          url: 'https://api.example.com/data',
+          data: {data: 100},
+          headers: {
+            'Content-Type': 'application/vnd.test',
+          },
+          jpath: 'data',
+          output: 'result',
+          'tls-verify': true,
+        };
+
+        const restClient = RESTClient(config, parametersMetadata, {});
+        mock.onPut(config.url, config.data).reply(config => {
+          const headers = config.headers ?? {};
+          expect(headers['Content-Type']).toBe('application/vnd.test');
+          expect(config.httpsAgent.options.rejectUnauthorized).toBe(true);
+          return [200, {data: 100}];
+        });
+
+        const result = await restClient.execute([
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+          },
+        ]);
+        const expectedResult = [
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+            result: 100,
+          },
+        ];
+
+        expect(result).toStrictEqual(expectedResult);
+      });
+
+      it('successfully applies RESTClient `POST` method to given input.(tls-verify is undefined and Content-Type is undefined)', async () => {
+        expect.assertions(3);
         const config = {
           method: 'POST',
           url: 'https://api.example.com/data',
@@ -111,7 +268,136 @@ describe('rest-client', () => {
         };
 
         const restClient = RESTClient(config, parametersMetadata, {});
-        mock.onPost(config.url, config.data).reply(200, {data: 100});
+        mock.onPost(config.url, config.data).reply(config => {
+          const headers = config.headers ?? {};
+          expect(headers['Content-Type']).toBe('application/json');
+          expect(config.httpsAgent.options.rejectUnauthorized).toBe(true);
+          return [200, {data: 100}];
+        });
+
+        const result = await restClient.execute([
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+          },
+        ]);
+        const expectedResult = [
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+            result: 100,
+          },
+        ];
+
+        expect(result).toStrictEqual(expectedResult);
+      });
+
+      it('successfully applies RESTClient `POST` method to given input.(tls-verify is defined and Content-Type is undefined)', async () => {
+        expect.assertions(3);
+        const config = {
+          method: 'POST',
+          url: 'https://api.example.com/data',
+          data: {data: 100},
+          'http-basic-authentication': {
+            username: 'yourUsername',
+            password: 'yourPassword',
+          },
+          'tls-verify': false,
+          jpath: 'data',
+          output: 'result',
+        };
+
+        const restClient = RESTClient(config, parametersMetadata, {});
+        mock.onPost(config.url, config.data).reply(config => {
+          const headers = config.headers ?? {};
+          expect(headers['Content-Type']).toBe('application/json');
+          expect(config.httpsAgent.options.rejectUnauthorized).toBe(false);
+          return [200, {data: 100}];
+        });
+        const result = await restClient.execute([
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+          },
+        ]);
+        const expectedResult = [
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+            result: 100,
+          },
+        ];
+
+        expect(result).toStrictEqual(expectedResult);
+      });
+
+      it('successfully applies RESTClient `POST` method to given input.(tls-verify is undefined and Content-Type is defined)', async () => {
+        expect.assertions(3);
+        const config = {
+          method: 'POST',
+          url: 'https://api.example.com/data',
+          data: {data: 100},
+          'http-basic-authentication': {
+            username: 'yourUsername',
+            password: 'yourPassword',
+          },
+          headers: {
+            'Content-Type': 'application/vnd.test',
+          },
+          jpath: 'data',
+          output: 'result',
+        };
+
+        const restClient = RESTClient(config, parametersMetadata, {});
+        mock.onPost(config.url, config.data).reply(config => {
+          const headers = config.headers ?? {};
+          expect(headers['Content-Type']).toBe('application/vnd.test');
+          expect(config.httpsAgent.options.rejectUnauthorized).toBe(true);
+          return [200, {data: 100}];
+        });
+
+        const result = await restClient.execute([
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+          },
+        ]);
+        const expectedResult = [
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+            result: 100,
+          },
+        ];
+
+        expect(result).toStrictEqual(expectedResult);
+      });
+
+      it('successfully applies RESTClient `POST` method to given input.(tls-verify is defined and Content-Type is defined)', async () => {
+        expect.assertions(3);
+        const config = {
+          method: 'POST',
+          url: 'https://api.example.com/data',
+          data: {data: 100},
+          'http-basic-authentication': {
+            username: 'yourUsername',
+            password: 'yourPassword',
+          },
+          headers: {
+            'Content-Type': 'application/vnd.test',
+          },
+          'tls-verify': false,
+          jpath: 'data',
+          output: 'result',
+        };
+
+        const restClient = RESTClient(config, parametersMetadata, {});
+        mock.onPost(config.url, config.data).reply(config => {
+          const headers = config.headers ?? {};
+          expect(headers['Content-Type']).toBe('application/vnd.test');
+          expect(config.httpsAgent.options.rejectUnauthorized).toBe(false);
+          return [200, {data: 100}];
+        });
 
         const result = await restClient.execute([
           {
@@ -212,7 +498,34 @@ describe('rest-client', () => {
         }
       });
 
-      it('rejects with output not number error.', async () => {
+      it('rejects with method not PUT, GET, or POST error.', async () => {
+        expect.assertions(1);
+        const config = {
+          method: 'DELETE',
+          url: 'https://api.example.com/data',
+          jpath: '$.wattage',
+          output: 'result',
+        };
+        mock.onGet(config.url).reply(200);
+
+        const restClient = RESTClient(config, parametersMetadata, {});
+        const input = [
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+          },
+        ];
+
+        try {
+          await restClient.execute(input);
+        } catch (error) {
+          if (error instanceof Error) {
+            expect(error.message).toEqual('Unsupported method: DELETE');
+          }
+        }
+      });
+
+      it('rejects with output not number error. (output is string)', async () => {
         expect.assertions(1);
         const config = {
           method: 'GET',
@@ -236,6 +549,35 @@ describe('rest-client', () => {
           if (error instanceof Error) {
             expect(error.message).toEqual(
               "Only numerical output is supported. 'Jack' is not a number."
+            );
+          }
+        }
+      });
+
+      it('rejects with output not number error. (output is array)', async () => {
+        expect.assertions(1);
+        const config = {
+          method: 'GET',
+          url: 'https://api.example.com/data',
+          jpath: '$.wattage',
+          output: 'result',
+        };
+        mock.onGet(config.url).reply(200, {wattage: [1, 42]});
+
+        const restClient = RESTClient(config, parametersMetadata, {});
+        const input = [
+          {
+            timestamp: '2024-03-01',
+            duration: 3600,
+          },
+        ];
+
+        try {
+          await restClient.execute(input);
+        } catch (error) {
+          if (error instanceof Error) {
+            expect(error.message).toEqual(
+              "Only numerical output is supported. '1,42' is not a number."
             );
           }
         }


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
- I updated and added test cases to `rest-client.test.ts`
    - The updated and added tests check that mock receives the below settings
      - `Content-Type: undefiend` and `tls-verify: true` when GET method without `Content-Type` and `tls-verify`
      - `Content-Type: undefiend` and `tls-verify: false` when GET method without `Content-Type` and with `tls-verify: false`
      - `Content-Type: application/json` and `tls-verify: true` when POST method without `Content-Type` and `tls-verify`
      - `Content-Type: application/json` and `tls-verify: false` when POST method without `Content-Type `and with `tls-verify: false`
      - `Content-Type: application/vnd.test ` and `tls-verify: true` when POST method with `Content-Type: application/vnd.test `and without` tls-verify`
      - `Content-Type: application/vnd.test ` and `tls-verify: false` when POST method with `Content-Type: application/vnd.test `and with `tls-verify: false`
      - `Content-Type: application/json` and `tls-verify: true` when PUT method without `Content-Type` and` tls-verify`
      - `Content-Type: application/json` and `tls-verify: false` when PUT method without `Content-Type` and with `tls-verify false`
      - `Content-Type: application/vnd.test ` and `tls-verify: true` when PUT method with `Content-Type: application/vnd.test` and without `tls-verify`
      - `Content-Type: application/vnd.test ` and `tls-verify: true` when PUT method with `Content-Type: application/vnd.test` and with `tls-verify: true`
  - I added other test cases
     - method is not `PUT`, `POST`, `GET `error
     - output not number error(output is string)
     - output not number error(output is array)



<!-- Make sure tests and lint pass on CI. -->

