### PR TITLE
feat(rest-client): timestamp insertion when used with observe

### DIFF
--- a/docs/rest-client.md
+++ b/docs/rest-client.md
@@ -8,7 +8,7 @@ You provide some query parameters including `url`, `method`, and so on. `url` is
 
 ### Plugin config
 
-The parameters are required in config: `method`, `url`, `data`, `headers`, `http-basic-authentication`, `tls-verify`, `jpath` and `output`.
+The parameters are required in config: `method`, `url`, `data`, `headers`, `http-basic-authentication`, `tls-verify`, `jpath`, `observtion-timestamp` and `output`.
 
 
 - `method`: HTTP method, you can choose `GET`, `PUT`, and `POST`
@@ -31,6 +31,7 @@ The parameters are required in config: `method`, `url`, `data`, `headers`, `http
     ```
 - `tls-verify`: optional, the server certificate is verified against the list of supplied CAs if true or undefined. `true` is set by default.
 - `jpath`: JSONPath expression and you can use it when using the GET method
+- `observation-timestamp`: optional, the execution timestamp will be automatically inserted into the `inputs` when using this plugin with `observe` if `true`. `false` is set by default. This option should not be set to `true` when used with `compute`. An error will occur if this option is set to `true` while a `timestamp` already exists in the `inputs`.
 - `output`: parameter name to store the result of this plugin
 
 ### Inputs
@@ -119,16 +120,16 @@ initialize:
         data: 
           wattage: 100
         output: result
+        observation-timestamp: true
         jpath: data
 tree:
   children:
     child:
       pipeline:
-        compute:
+        observe:
           - wattage-in-post-request
       inputs:
-        - timestamp: 2023-07-06T00:00 
-          duration: 100
+        - duration: 100
 ```
 You can set `community-plugins` to `path` insted of `https://github.com/Green-Software-Foundation/community-plugins`. 
 You can run this example as following when you save it to `./examples/manifests/rest-client.yml`:
@@ -156,6 +157,7 @@ The required parameters are:
 - `http-basic-authentication` : this must be a string
 - `tls-verify`: this must be a booleam
 - `jpath`: this must be a string
+- `observation-timestamp`: this must be a booleam
 - `output`: this must be a string
 
 You can fix this error by checking you are providing valid values for each parameter in the config.

--- a/docs/rest-client.md
+++ b/docs/rest-client.md
@@ -8,7 +8,7 @@ You provide some query parameters including `url`, `method`, and so on. `url` is
 
 ### Plugin config
 
-The parameters are required in config: `method`, `url`, `data`, `headers`, `http-basic-authentication`, `tls-verify`, `jpath`, `observtion-timestamp` and `output`.
+The parameters are required in config: `method`, `url`, `data`, `headers`, `http-basic-authentication`, `tls-verify`, `jpath`, `observe-mode` and `output`.
 
 
 - `method`: HTTP method, you can choose `GET`, `PUT`, and `POST`
@@ -31,7 +31,7 @@ The parameters are required in config: `method`, `url`, `data`, `headers`, `http
     ```
 - `tls-verify`: optional, the server certificate is verified against the list of supplied CAs if true or undefined. `true` is set by default.
 - `jpath`: JSONPath expression and you can use it when using the GET method
-- `observation-timestamp`: optional, the execution timestamp will be automatically inserted into the `inputs` when using this plugin with `observe` if `true`. `false` is set by default. This option should not be set to `true` when used with `compute`. An error will occur if this option is set to `true` while a `timestamp` already exists in the `inputs`.
+- `observe-mode`: optional, the execution timestamp will be automatically inserted into the `inputs` when using this plugin with `observe` if `true`. `false` is set by default. This option should not be set to `true` when used with `compute`. An error will occur if this option is set to `true` while a `timestamp` already exists in the `inputs`.
 - `output`: parameter name to store the result of this plugin
 
 ### Inputs
@@ -120,7 +120,7 @@ initialize:
         data: 
           wattage: 100
         output: result
-        observation-timestamp: true
+        observe-mode: true
         jpath: data
 tree:
   children:
@@ -157,7 +157,7 @@ The required parameters are:
 - `http-basic-authentication` : this must be a string
 - `tls-verify`: this must be a booleam
 - `jpath`: this must be a string
-- `observation-timestamp`: this must be a booleam
+- `observe-mode`: this must be a booleam
 - `output`: this must be a string
 
 You can fix this error by checking you are providing valid values for each parameter in the config.

--- a/src/__tests__/lib/rest-client.test.ts
+++ b/src/__tests__/lib/rest-client.test.ts
@@ -55,13 +55,13 @@ describe('rest-client', () => {
 
         const result = await restClient.execute([
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ]);
         const expectedResult = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
             result: 100,
           },
@@ -90,13 +90,13 @@ describe('rest-client', () => {
 
         const result = await restClient.execute([
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ]);
         const expectedResult = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
             result: 100,
           },
@@ -125,13 +125,13 @@ describe('rest-client', () => {
 
         const result = await restClient.execute([
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ]);
         const expectedResult = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
             result: 100,
           },
@@ -161,13 +161,13 @@ describe('rest-client', () => {
 
         const result = await restClient.execute([
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ]);
         const expectedResult = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
             result: 100,
           },
@@ -199,13 +199,13 @@ describe('rest-client', () => {
 
         const result = await restClient.execute([
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ]);
         const expectedResult = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
             result: 100,
           },
@@ -238,13 +238,13 @@ describe('rest-client', () => {
 
         const result = await restClient.execute([
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ]);
         const expectedResult = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
             result: 100,
           },
@@ -277,13 +277,13 @@ describe('rest-client', () => {
 
         const result = await restClient.execute([
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ]);
         const expectedResult = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
             result: 100,
           },
@@ -316,13 +316,13 @@ describe('rest-client', () => {
         });
         const result = await restClient.execute([
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ]);
         const expectedResult = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
             result: 100,
           },
@@ -358,13 +358,13 @@ describe('rest-client', () => {
 
         const result = await restClient.execute([
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ]);
         const expectedResult = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
             result: 100,
           },
@@ -401,13 +401,13 @@ describe('rest-client', () => {
 
         const result = await restClient.execute([
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ]);
         const expectedResult = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
             result: 100,
           },
@@ -433,13 +433,13 @@ describe('rest-client', () => {
 
         const result = await restClient.execute([
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ]);
         const expectedResult = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
             wattage: 100,
           },
@@ -461,7 +461,7 @@ describe('rest-client', () => {
         const restClient = RESTClient(config, parametersMetadata, {});
         const input = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ];
@@ -483,7 +483,7 @@ describe('rest-client', () => {
         const restClient = RESTClient();
         const input = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ];
@@ -511,7 +511,7 @@ describe('rest-client', () => {
         const restClient = RESTClient(config, parametersMetadata, {});
         const input = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ];
@@ -538,7 +538,7 @@ describe('rest-client', () => {
         const restClient = RESTClient(config, parametersMetadata, {});
         const input = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ];
@@ -567,7 +567,7 @@ describe('rest-client', () => {
         const restClient = RESTClient(config, parametersMetadata, {});
         const input = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ];
@@ -596,7 +596,7 @@ describe('rest-client', () => {
         const restClient = RESTClient(config, parametersMetadata, {});
         const input = [
           {
-            timestamp: '2024-03-01',
+            timestamp: '2021-01-01T00:00:00Z',
             duration: 3600,
           },
         ];
@@ -606,6 +606,112 @@ describe('rest-client', () => {
         } catch (error) {
           if (error instanceof Error) {
             expect(error.message).toEqual('The response data has no content.');
+          }
+        }
+      });
+
+      it('successfully applies RESTCLient to given input. (observation-timestamp is false)', async () => {
+        expect.assertions(3);
+        const config = {
+          method: 'GET',
+          url: 'https://api.example.com/data',
+          'tls-verify': false,
+          jpath: '$.data',
+          output: 'result',
+          'observation-timestamp': false,
+        };
+
+        const restClient = RESTClient(config, parametersMetadata, {});
+        mock.onGet(config.url).reply(config => {
+          const headers = config.headers ?? {};
+          expect(config.httpsAgent.options.rejectUnauthorized).toBe(false);
+          expect(headers['Content-Type']).toBeUndefined();
+          return [200, {data: 100}];
+        });
+
+        const result = await restClient.execute([
+          {
+            timestamp: '2021-01-01T00:00:00Z',
+            duration: 3600,
+          },
+        ]);
+        const expectedResult = [
+          {
+            timestamp: '2021-01-01T00:00:00Z',
+            duration: 3600,
+            result: 100,
+          },
+        ];
+
+        expect(result).toStrictEqual(expectedResult);
+      });
+
+      it('successfully applies RESTClient to given input. (observation-timestamp is true)', async () => {
+        expect.assertions(3);
+
+        const fixedDate = new Date('2021-01-01T00:00:00Z');
+        jest.useFakeTimers().setSystemTime(fixedDate);
+
+        const config = {
+          method: 'GET',
+          url: 'https://api.example.com/data',
+          jpath: '$.data',
+          'observation-timestamp': true,
+          output: 'result',
+        };
+
+        const restClient = RESTClient(config, parametersMetadata, {});
+        mock.onGet(config.url).reply(config => {
+          const headers = config.headers ?? {};
+          expect(config.httpsAgent.options.rejectUnauthorized).toBe(true);
+          expect(headers['Content-Type']).toBeUndefined();
+          return [200, {data: 100}];
+        });
+
+        const result = await restClient.execute([
+          {
+            duration: 3600,
+          },
+        ]);
+        const expectedResult = [
+          {
+            timestamp: '2021-01-01T00:00:00Z',
+            duration: 3600,
+            result: 100,
+          },
+        ];
+
+        expect(result).toStrictEqual(expectedResult);
+
+        jest.useRealTimers();
+      });
+
+      it('rejects with timestamp already exists in input error.', async () => {
+        expect.assertions(1);
+        const config = {
+          method: 'GET',
+          url: 'https://api.example.com/data',
+          jpath: '$.data',
+          output: 'result',
+          'observation-timestamp': true,
+        };
+        mock.onGet(config.url).reply(200, {data: 100});
+
+        const restClient = RESTClient(config, parametersMetadata, {});
+        const input = [
+          {
+            timestamp: '2021-01-01T00:00:00Z',
+            duration: 3600,
+          },
+        ];
+
+        try {
+          await restClient.execute(input);
+        } catch (error) {
+          if (error instanceof Error) {
+            expect(error.message).toEqual(
+              'timestamp has already existed in inputs. Please set observation-timestamp to false.'
+            );
           }
         }
       });

--- a/src/__tests__/lib/rest-client.test.ts
+++ b/src/__tests__/lib/rest-client.test.ts
@@ -610,7 +610,7 @@ describe('rest-client', () => {
         }
       });
 
-      it('successfully applies RESTCLient to given input. (observation-timestamp is false)', async () => {
+      it('successfully applies RESTCLient to given input. (observe-mode is false)', async () => {
         expect.assertions(3);
         const config = {
           method: 'GET',
@@ -618,7 +618,7 @@ describe('rest-client', () => {
           'tls-verify': false,
           jpath: '$.data',
           output: 'result',
-          'observation-timestamp': false,
+          'observe-mode': false,
         };
 
         const restClient = RESTClient(config, parametersMetadata, {});
@@ -646,7 +646,7 @@ describe('rest-client', () => {
         expect(result).toStrictEqual(expectedResult);
       });
 
-      it('successfully applies RESTClient to given input. (observation-timestamp is true)', async () => {
+      it('successfully applies RESTClient to given input. (observe-mode is true)', async () => {
         expect.assertions(3);
 
         const fixedDate = new Date('2021-01-01T00:00:00Z');
@@ -656,7 +656,7 @@ describe('rest-client', () => {
           method: 'GET',
           url: 'https://api.example.com/data',
           jpath: '$.data',
-          'observation-timestamp': true,
+          'observe-mode': true,
           output: 'result',
         };
 
@@ -693,7 +693,7 @@ describe('rest-client', () => {
           url: 'https://api.example.com/data',
           jpath: '$.data',
           output: 'result',
-          'observation-timestamp': true,
+          'observe-mode': true,
         };
         mock.onGet(config.url).reply(200, {data: 100});
 
@@ -710,7 +710,7 @@ describe('rest-client', () => {
         } catch (error) {
           if (error instanceof Error) {
             expect(error.message).toEqual(
-              'timestamp has already existed in inputs. Please set observation-timestamp to false.'
+              'timestamp has already existed in inputs. Please set observe-mode to false.'
             );
           }
         }

--- a/src/lib/rest-client/index.ts
+++ b/src/lib/rest-client/index.ts
@@ -23,7 +23,7 @@ export const RESTClient = PluginFactory({
       headers: z.record(z.string(), z.any()).optional(),
       'tls-verify': z.boolean().optional(),
       jpath: z.string(),
-      'observation-timestamp': z.boolean().optional(),
+      'observe-mode': z.boolean().optional(),
       output: z.string(),
     });
 
@@ -135,10 +135,10 @@ const addTimestamp = (
   result: any
 ) => {
   const {output} = config;
-  if (config['observation-timestamp']) {
+  if (config['observe-mode']) {
     if (inputs.some((item: any) => 'timestamp' in item)) {
       throw new Error(
-        'timestamp has already existed in inputs. Please set observation-timestamp to false.'
+        'timestamp has already existed in inputs. Please set observe-mode to false.'
       );
     } else {
       const isotimestamp = new Date().toISOString();


### PR DESCRIPTION
… compute

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
- I’ve added a feature that automatically inserts the execution timestamp into the `inputs` when this plugin is used with `observe`. If the plugin is used with `observe` and a `timestamp` already exists in the `inputs`, an error will be returned
- 


<!-- Make sure tests and lint pass on CI. -->

